### PR TITLE
Madninja/api reboot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helium-api"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Marc Nijdam <marc@helium.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ serde =  "1"
 serde_derive = "1"
 serde_json = "1"
 base64 = "0"
+rust_decimal = "1"
 helium-proto = { git = "https://github.com/helium/proto" }

--- a/src/hnt.rs
+++ b/src/hnt.rs
@@ -1,0 +1,53 @@
+use rust_decimal::prelude::*;
+use rust_decimal::Decimal;
+use std::str::FromStr;
+
+#[derive(Clone, Copy, Debug)]
+pub struct Hnt(Decimal);
+
+const HNT_TO_BONES_SCALAR: i32 = 100_000_000;
+
+impl FromStr for Hnt {
+    type Err = Box<dyn std::error::Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let data = Decimal::from_str(s)
+            .or_else(|_| Decimal::from_scientific(s))
+            .unwrap();
+
+        if data.scale() > 8 {
+            Err(format!("Invalid conversion from string {}", s).into())
+        } else {
+            Ok(Hnt(data))
+        }
+    }
+}
+
+impl Hnt {
+    pub fn to_bones(&self) -> u64 {
+        if let Some(scaled_dec) = self.0.checked_mul(HNT_TO_BONES_SCALAR.into()) {
+            if let Some(num) = scaled_dec.to_u64() {
+                return num;
+            }
+        }
+        panic!("Hnt has been constructed with invalid data")
+    }
+
+    pub fn from_bones(bones: u64) -> Self {
+        if let Some(mut data) = Decimal::from_u64(bones) {
+            data.set_scale(8).unwrap();
+            return Hnt(data);
+        }
+        panic!("Bones value could not be parsed into Decimal")
+    }
+
+    pub fn get_decimal(&self) -> Decimal {
+        self.0
+    }
+}
+
+impl ToString for Hnt {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 /// The default timeout for API requests
 pub const DEFAULT_TIMEOUT: u64 = 120;
 /// The default base URL if none is specified.
-pub const DEFAULT_BASE_URL: &str = "https://explorer.helium.foundation/api";
+pub const DEFAULT_BASE_URL: &str = "https://api.helium.com/v1";
 
 pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -26,7 +26,7 @@ pub struct Account {
     /// The data credit balance of the wallet known to the API
     pub dc_balance: u64,
     /// The security token balance of the wallet known to the API
-    pub security_balance: u64,
+    pub sec_balance: u64,
     /// The current nonce for the account
     pub nonce: u64,
 }
@@ -52,21 +52,21 @@ pub struct Hotspot {
     /// PoC challenges.
     pub location: String, // h3
     /// The long version of city for the last asserted location
-    pub long_city: String,
+    pub long_city: Option<String>,
     /// The long version of country for the last asserted location
-    pub long_country: String,
+    pub long_country: Option<String>,
     /// The long version of state for the last asserted location
-    pub long_state: String,
+    pub long_state: Option<String>,
     /// The long version of street for the last asserted location
-    pub long_street: String,
+    pub long_street: Option<String>,
     /// The short version of city for the last asserted location
-    pub short_city: String,
+    pub short_city: Option<String>,
     /// The short version of country for the last asserted location
-    pub short_country: String,
+    pub short_country: Option<String>,
     /// The short version of state for the last asserted location
-    pub short_state: String,
+    pub short_state: Option<String>,
     /// The short version of street for the last asserted location
-    pub short_street: String,
+    pub short_street: Option<String>,
     /// The current known score of the hotspos
     pub score: f32,
     /// The last block the score for the hotspot was updated. None if
@@ -81,7 +81,7 @@ pub(crate) struct Data<T> {
 
 #[derive(Clone, Debug)]
 pub struct Client {
-    base_url: &'static str,
+    base_url: String,
     client: reqwest::Client,
 }
 
@@ -89,7 +89,7 @@ impl Default for Client {
     /// Create a new client using the hosted Helium API at
     /// explorer.helium.foundation
     fn default() -> Self {
-        Self::new_with_base_url(DEFAULT_BASE_URL)
+        Self::new_with_base_url(DEFAULT_BASE_URL.to_string())
     }
 }
 
@@ -97,14 +97,14 @@ impl Client {
     /// Create a new client using a given base URL and a default
     /// timeout. The library will use absoluate paths based on this
     /// base_url.
-    pub fn new_with_base_url(base_url: &'static str) -> Self {
+    pub fn new_with_base_url(base_url: String) -> Self {
         Self::new_with_timeout(base_url, DEFAULT_TIMEOUT)
     }
 
     /// Create a new client using a given base URL, and request
     /// timeout value.  The library will use absoluate paths based on
     /// the given base_url.
-    pub fn new_with_timeout(base_url: &'static str, timeout: u64) -> Self {
+    pub fn new_with_timeout(base_url: String, timeout: u64) -> Self {
         let client = reqwest::Client::builder()
             .gzip(true)
             .timeout(Duration::from_secs(timeout))
@@ -136,7 +136,7 @@ impl Client {
 
     /// Get hotspots for a given wallet address
     pub fn get_hotspots(&self, address: &str) -> Result<Vec<Hotspot>> {
-        self.fetch::<Vec<Hotspot>>(format!("/accounts/{}/gateways", address))
+        self.fetch::<Vec<Hotspot>>(format!("/accounts/{}/hotspots", address))
     }
 
     /// Get details for a given hotspot address


### PR DESCRIPTION
* This gets ready for the new Helium API at `api.helium.io` 
* Adds support for `HNT` by exposing an `Hnt` type to convert to/from fixed decimal encoding