### PR TITLE
Fix examples

### DIFF
--- a/examples/account.rs
+++ b/examples/account.rs
@@ -1,7 +1,7 @@
 use helium_api::Client;
 
 fn main() {
-    let client = Client::new();
+    let client = Client::default();
     let account = client.get_account("13buBykFQf5VaQtv7mWj2PBY9Lq4i1DeXhg7C4Vbu3ppzqqNkTH");
     println!("Account: {:?}", account);
 }

--- a/examples/hotspot.rs
+++ b/examples/hotspot.rs
@@ -1,7 +1,7 @@
 use helium_api::Client;
 
 fn main() {
-    let client = Client::new();
+    let client = Client::default();
     let hotspot = client.get_hotspot("11VKaN7fEvDm6NaGhcZtNSU1KAQQmTSwuuJsYYEqzh8mSWkoEUd");
     println!("Hotspot: {:?}", hotspot);
     let hotspots = client.get_hotspots("13buBykFQf5VaQtv7mWj2PBY9Lq4i1DeXhg7C4Vbu3ppzqqNkTH");


### PR DESCRIPTION
helium-api-rs now uses `default` instead of `new`, so the examples needed updating.