### PR TITLE
Provide default value for speculative nonce

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ mod hnt;
 pub use hnt::Hnt;
 
 use helium_proto::{BlockchainTxn, Message, Txn};
-use reqwest;
 use serde::{de::DeserializeOwned, Serialize};
 use std::time::Duration;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub struct Account {
     /// The current nonce for the account
     pub nonce: u64,
     /// The speculative nonce for the account
+    #[serde(default)]
     pub speculative_nonce: u64,
 }
 


### PR DESCRIPTION
When an account is unknown to the backend, it appears the json response does not include a speculative nonce. serde will provide a default of 0 if you provide the default flag for a u64 field.