### PR TITLE
Adds Block Height

### DIFF
--- a/examples/height.rs
+++ b/examples/height.rs
@@ -4,6 +4,6 @@ fn main() {
     let client = Client::default();
     match client.get_height() {
         Ok(height) => println!("Block Height: {}", height),
-        Err(e) => println!("Error fetching block height: {:?}", e)
+        Err(e) => println!("Error fetching block height: {:?}", e),
     }
 }

--- a/examples/height.rs
+++ b/examples/height.rs
@@ -1,0 +1,9 @@
+use helium_api::Client;
+
+fn main() {
+    let client = Client::default();
+    match client.get_height() {
+        Ok(height) => println!("Block Height: {}", height),
+        Err(e) => println!("Error fetching block height: {:?}", e)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,12 @@ pub struct Geocode {
 }
 
 #[derive(Clone, Deserialize, Debug)]
+pub struct Height {
+    /// The current block height of the chain.
+    pub height: u64,
+}
+
+#[derive(Clone, Deserialize, Debug)]
 pub struct Hotspot {
     /// The address of the hotspots. This is the public key in base58
     /// check-encoding of the hotspot.
@@ -154,6 +160,12 @@ impl Client {
     /// Get wallet information for a given address
     pub fn get_account(&self, address: &str) -> Result<Account> {
         self.fetch::<Account>(format!("/accounts/{}", address))
+    }
+
+    /// Get the current block height
+    pub fn get_height(&self) -> Result<u64> {
+        let result = self.fetch::<Height>("/blocks/height".to_string())?;
+        Ok(result.height)
     }
 
     /// Get hotspots for a given wallet address


### PR DESCRIPTION
This PR adds method to client `height` to return the current block height. Also adds an example for call.