### PR TITLE
get current oracle price

### DIFF
--- a/examples/oracle_price.rs
+++ b/examples/oracle_price.rs
@@ -1,0 +1,14 @@
+use helium_api::{error::Result, Client};
+
+fn main() -> Result<()> {
+    let client = Client::default();
+
+    let oracle_price = client.get_oracle_price_current()?;
+    println!("Current {:?}", oracle_price);
+
+    let predicted_prices = client.get_oracle_price_predicted()?;
+    for predicted_price in predicted_prices {
+        println!("{:?}", predicted_price);
+    }
+    Ok(())
+}

--- a/src/bones_macro.rs
+++ b/src/bones_macro.rs
@@ -1,0 +1,48 @@
+#[macro_export]
+macro_rules! decimal_bones {
+    ( $t:tt  , $s:ident) => {
+        use crate::error;
+        use rust_decimal::prelude::*;
+        use rust_decimal::Decimal;
+        use std::str::FromStr;
+
+        impl FromStr for $t {
+            type Err = error::Error;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                let data = Decimal::from_str(s)
+                    .or_else(|_| Decimal::from_scientific(s))
+                    .unwrap();
+
+                if data.scale() > 8 {
+                    Err(error::decimals(s))
+                } else {
+                    Ok($t(data))
+                }
+            }
+        }
+
+        impl $t {
+            pub fn to_bones(&self) -> u64 {
+                if let Some(scaled_dec) = self.0.checked_mul($s.into()) {
+                    if let Some(num) = scaled_dec.to_u64() {
+                        return num;
+                    }
+                }
+                panic!("Type has been constructed with invalid data")
+            }
+
+            pub fn from_bones(bones: u64) -> Self {
+                if let Some(mut data) = Decimal::from_u64(bones) {
+                    data.set_scale(8).unwrap();
+                    return $t(data);
+                }
+                panic!("Value could not be parsed into Decimal")
+            }
+
+            pub fn get_decimal(&self) -> Decimal {
+                self.0
+            }
+        }
+    };
+}

--- a/src/bones_macro.rs
+++ b/src/bones_macro.rs
@@ -44,5 +44,11 @@ macro_rules! decimal_bones {
                 self.0
             }
         }
+
+        impl ToString for $t {
+            fn to_string(&self) -> String {
+                self.0.to_string()
+            }
+        }
     };
 }

--- a/src/hnt.rs
+++ b/src/hnt.rs
@@ -1,55 +1,5 @@
-use crate::error;
-use rust_decimal::prelude::*;
-use rust_decimal::Decimal;
-use serde::Serialize;
-use std::str::FromStr;
-
-#[derive(Clone, Copy, Debug, Serialize)]
+const HNT_TO_BONES_SCALAR: i32 = 100_000_000;
+#[derive(Clone, Copy, Debug)]
 pub struct Hnt(Decimal);
 
-const HNT_TO_BONES_SCALAR: i32 = 100_000_000;
-
-impl FromStr for Hnt {
-    type Err = error::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let data = Decimal::from_str(s)
-            .or_else(|_| Decimal::from_scientific(s))
-            .unwrap();
-
-        if data.scale() > 8 {
-            Err(error::decimals(s))
-        } else {
-            Ok(Hnt(data))
-        }
-    }
-}
-
-impl Hnt {
-    pub fn to_bones(&self) -> u64 {
-        if let Some(scaled_dec) = self.0.checked_mul(HNT_TO_BONES_SCALAR.into()) {
-            if let Some(num) = scaled_dec.to_u64() {
-                return num;
-            }
-        }
-        panic!("Hnt has been constructed with invalid data")
-    }
-
-    pub fn from_bones(bones: u64) -> Self {
-        if let Some(mut data) = Decimal::from_u64(bones) {
-            data.set_scale(8).unwrap();
-            return Hnt(data);
-        }
-        panic!("Bones value could not be parsed into Decimal")
-    }
-
-    pub fn get_decimal(&self) -> Decimal {
-        self.0
-    }
-}
-
-impl ToString for Hnt {
-    fn to_string(&self) -> String {
-        self.0.to_string()
-    }
-}
+decimal_bones!(Hnt, HNT_TO_BONES_SCALAR);

--- a/src/hnt.rs
+++ b/src/hnt.rs
@@ -1,5 +1,7 @@
+use serde::Serialize;
+
 const HNT_TO_BONES_SCALAR: i32 = 100_000_000;
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize)]
 pub struct Hnt(Decimal);
 
 decimal_bones!(Hnt, HNT_TO_BONES_SCALAR);

--- a/src/hst.rs
+++ b/src/hst.rs
@@ -1,55 +1,5 @@
-use crate::error;
-use rust_decimal::prelude::*;
-use rust_decimal::Decimal;
-use serde::Serialize;
-use std::str::FromStr;
-
-#[derive(Clone, Copy, Debug, Serialize)]
+const HST_TO_BONES_SCALAR: i32 = 100_000_000;
+#[derive(Clone, Copy, Debug)]
 pub struct Hst(Decimal);
 
-const HST_TO_BONES_SCALAR: i32 = 100_000_000;
-
-impl FromStr for Hst {
-    type Err = error::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let data = Decimal::from_str(s)
-            .or_else(|_| Decimal::from_scientific(s))
-            .unwrap();
-
-        if data.scale() > 8 {
-            Err(error::decimals(s))
-        } else {
-            Ok(Hst(data))
-        }
-    }
-}
-
-impl Hst {
-    pub fn to_bones(&self) -> u64 {
-        if let Some(scaled_dec) = self.0.checked_mul(HST_TO_BONES_SCALAR.into()) {
-            if let Some(num) = scaled_dec.to_u64() {
-                return num;
-            }
-        }
-        panic!("Hst has been constructed with invalid data")
-    }
-
-    pub fn from_bones(bones: u64) -> Self {
-        if let Some(mut data) = Decimal::from_u64(bones) {
-            data.set_scale(8).unwrap();
-            return Hst(data);
-        }
-        panic!("Bones value could not be parsed into Decimal")
-    }
-
-    pub fn get_decimal(&self) -> Decimal {
-        self.0
-    }
-}
-
-impl ToString for Hst {
-    fn to_string(&self) -> String {
-        self.0.to_string()
-    }
-}
+decimal_bones!(Hst, HST_TO_BONES_SCALAR);

--- a/src/hst.rs
+++ b/src/hst.rs
@@ -1,5 +1,7 @@
+use serde::Serialize;
+
 const HST_TO_BONES_SCALAR: i32 = 100_000_000;
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize)]
 pub struct Hst(Decimal);
 
 decimal_bones!(Hst, HST_TO_BONES_SCALAR);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub const DEFAULT_TIMEOUT: u64 = 120;
 /// The default base URL if none is specified.
 pub const DEFAULT_BASE_URL: &str = "https://api.helium.io/v1";
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug, Serialize)]
 /// Represents a wallet on the blockchain.
 pub struct Account {
     /// The wallet address is the base58 check-encoded public key of
@@ -42,7 +42,7 @@ pub struct Account {
     pub speculative_sec_nonce: u64,
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug, Serialize)]
 pub struct Geocode {
     /// The long version of city for the last asserted location
     pub long_city: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,8 +129,8 @@ pub struct Client {
 #[derive(Clone, Deserialize, Debug)]
 pub struct OraclePredictions {
     #[serde(with = "crate::oracle_price::deserializer")]
-    price: OraclePrice,
-    time: usize,
+    pub price: OraclePrice,
+    pub time: usize,
 }
 
 impl Default for Client {

--- a/src/oracle_price.rs
+++ b/src/oracle_price.rs
@@ -1,0 +1,24 @@
+use super::decimal_bones;
+
+const ORACLE_PRICE_TO_BONES_SCALAR: i32 = 100_000_000;
+#[derive(Clone, Copy, Debug)]
+pub struct OraclePrice(Decimal);
+
+decimal_bones!(OraclePrice, ORACLE_PRICE_TO_BONES_SCALAR);
+
+pub mod deserializer {
+    use super::OraclePrice;
+    use serde::{Deserialize, Deserializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<OraclePrice, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let opt: Option<u64> = Option::deserialize(deserializer)?;
+        if let Some(s) = opt {
+            Ok(OraclePrice::from_bones(s))
+        } else {
+            panic!("Unexpected user of Oracle Desrializer")
+        }
+    }
+}

--- a/src/oracle_price.rs
+++ b/src/oracle_price.rs
@@ -1,7 +1,7 @@
-use super::decimal_bones;
+use serde::Serialize;
 
 const ORACLE_PRICE_TO_BONES_SCALAR: i32 = 100_000_000;
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize)]
 pub struct OraclePrice(Decimal);
 
 decimal_bones!(OraclePrice, ORACLE_PRICE_TO_BONES_SCALAR);


### PR DESCRIPTION
Provides functions for getting current and predicted oracle prices, along with new example.

Includes refactoring of the "decimal to bones" logic that was duplicated between `hnt` and `hst` modules as similar logic needed to be applied to `oracle_price`.