### PR TITLE
Expand Account model

### DIFF
--- a/examples/validator.rs
+++ b/examples/validator.rs
@@ -2,8 +2,7 @@ use helium_api::{models::QueryTimeRange, validators, Client, IntoVec};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // TODO: Switch back to mainnet when validators go live
-    let client = Client::new_with_base_url("https://testnet-api.helium.wtf/v1".to_string());
+    let client = Client::default();
 
     let stats = validators::stats(&client).await?;
     println!("Stats {:?}", stats);

--- a/src/models/account.rs
+++ b/src/models/account.rs
@@ -11,6 +11,9 @@ pub struct Account {
     /// The latest balance of the wallet known to the API
     #[serde(deserialize_with = "Hnt::deserialize")]
     pub balance: Hnt,
+    /// The latest staked_balance of the wallet known to the API
+    #[serde(deserialize_with = "Hnt::deserialize")]
+    pub staked_balance: Hnt,
     /// The data credit balance of the wallet known to the API
     pub dc_balance: u64,
     /// The security token balance of the wallet known to the API

--- a/src/models/account.rs
+++ b/src/models/account.rs
@@ -8,19 +8,25 @@ pub struct Account {
     /// The wallet address is the base58 check-encoded public key of
     /// the wallet.
     pub address: String,
-    /// The latest balance of the wallet known to the API
+    /// Block height of the API when query was made
+    pub block: u64,
+    /// The latest balance of the wallet at block height
     #[serde(deserialize_with = "Hnt::deserialize")]
     pub balance: Hnt,
-    /// The latest staked_balance of the wallet known to the API
+    /// The latest staked_balance of the wallet at block height
     #[serde(deserialize_with = "Hnt::deserialize")]
     pub staked_balance: Hnt,
-    /// The data credit balance of the wallet known to the API
+    /// The data credit balance of the wallet known at block height
     pub dc_balance: u64,
-    /// The security token balance of the wallet known to the API
+    /// The security token balance of the wallet at block height
     #[serde(deserialize_with = "Hst::deserialize")]
     pub sec_balance: Hst,
     /// The current nonce for the account
     pub nonce: u64,
+    /// The current sec_nonce for the account
+    pub sec_nonce: u64,
+    /// The current dc_nonce for the account
+    pub dc_nonce: u64,
     /// The speculative nonce for the account
     #[serde(default)]
     pub speculative_nonce: u64,


### PR DESCRIPTION
Primarily, this PR targets exposing the `staked_balance` but generally expands the account model to include everything included at the endpoint (https://github.com/helium/helium-ledger-app/issues/42).

Also a small fix to `examples/validator.rs` to target mainnet.