### PR TITLE
u64 serde for values

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: -- -Dclippy::all
 
+      - name: Run tests
+        run: cargo test
+
       - name: Build
         run: cargo build --all
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,4 @@ thiserror = "1"
 [dev-dependencies]
 tokio = {version = "1", features = ["full"]}
 futures-util = "0"
-serde_test = "1
-"
+serde_test = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,5 @@ thiserror = "1"
 [dev-dependencies]
 tokio = {version = "1", features = ["full"]}
 futures-util = "0"
+serde_test = "1
+"

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -51,7 +51,7 @@ mod test {
 
     #[test]
     async fn all() {
-        let client = Client::default();
+        let client = get_test_client();
         let accounts = accounts::all(&client)
             .take(10)
             .into_vec()
@@ -62,7 +62,7 @@ mod test {
 
     #[test]
     async fn get() {
-        let client = Client::default();
+        let client = get_test_client();
         let account = accounts::get(
             &client,
             "13WRNw4fmssJBvMqMnREwe1eCvUVXfnWXSXGcWXyVvAnQUF3D9R",
@@ -77,7 +77,7 @@ mod test {
 
     #[test]
     async fn ouis() {
-        let client = Client::default();
+        let client = get_test_client();
         let ouis = accounts::ouis(
             &client,
             "13tyMLKRFYURNBQqLSqNJg9k41maP1A7Bh8QYxR13oWv7EnFooc",
@@ -90,7 +90,7 @@ mod test {
 
     #[test]
     async fn hotspots() {
-        let client = Client::default();
+        let client = get_test_client();
         let hotspots = accounts::hotspots(
             &client,
             "13WRNw4fmssJBvMqMnREwe1eCvUVXfnWXSXGcWXyVvAnQUF3D9R",
@@ -103,7 +103,7 @@ mod test {
 
     #[test]
     async fn richest() {
-        let client = Client::default();
+        let client = get_test_client();
         let richest = accounts::richest(&client, Some(10))
             .await
             .expect("richest list");

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -13,7 +13,7 @@ mod test {
 
     #[test]
     async fn heigh() {
-        let client = Client::default();
+        let client = get_test_client();
         let height = blocks::height(&client).await.expect("height");
         assert!(height > 0);
     }

--- a/src/hotspots.rs
+++ b/src/hotspots.rs
@@ -19,7 +19,7 @@ mod test {
 
     #[test]
     async fn all() {
-        let client = Client::default();
+        let client = get_test_client();
         let hotspots = hotspots::all(&client)
             .take(10)
             .into_vec()
@@ -30,7 +30,7 @@ mod test {
 
     #[test]
     async fn get() {
-        let client = Client::default();
+        let client = get_test_client();
         let hotspot = hotspots::get(
             &client,
             "112vvSrNAwJRSmR54aqFLEhbr6cy6T4Ufuja4VWVrxvkUAUxL2yG",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,3 +183,10 @@ pub trait IntoVec: StreamExt {
         self.collect::<Vec<Result<T>>>().await.into_iter().collect()
     }
 }
+
+#[cfg(test)]
+fn get_test_client() -> Client {
+    const USER_AGENT: &str = "helium-api-test/0.1.0";
+    const BASE_URL: &str = "https://api.helium.io/v1";
+    Client::new_with_base_url(BASE_URL.into(), USER_AGENT)
+}

--- a/src/models/account.rs
+++ b/src/models/account.rs
@@ -12,7 +12,6 @@ pub struct Account {
     /// is no on-chain record of this account.
     pub block: Option<u64>,
     /// The latest balance of the wallet at block height
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub balance: Hnt,
     /// The latest staked_balance of the wallet at block height
     #[serde(deserialize_with = "Hnt::deserialize")]

--- a/src/models/transactions/add_gateway_v1.rs
+++ b/src/models/transactions/add_gateway_v1.rs
@@ -8,6 +8,5 @@ pub struct AddGatewayV1 {
     pub owner: String,
     pub payer: String,
     pub gateway: String,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub staking_fee: Hnt,
 }

--- a/src/models/transactions/assert_location_v1.rs
+++ b/src/models/transactions/assert_location_v1.rs
@@ -10,6 +10,5 @@ pub struct AssertLocationV1 {
     pub payer: Option<String>,
     pub gateway: String,
     pub location: String,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub staking_fee: Hnt,
 }

--- a/src/models/transactions/assert_location_v2.rs
+++ b/src/models/transactions/assert_location_v2.rs
@@ -12,6 +12,5 @@ pub struct AssertLocationV2 {
     pub gateway: String,
     pub location: String,
     pub elevation: i64,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub staking_fee: Hnt,
 }

--- a/src/models/transactions/coinbase_v1.rs
+++ b/src/models/transactions/coinbase_v1.rs
@@ -5,6 +5,5 @@ use serde::{Deserialize, Serialize};
 pub struct CoinbaseV1 {
     pub hash: String,
     pub payee: String,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub amount: Hnt,
 }

--- a/src/models/transactions/create_htlc_v1.rs
+++ b/src/models/transactions/create_htlc_v1.rs
@@ -8,7 +8,6 @@ pub struct CreateHtlcV1 {
     pub nonce: u64,
     pub payee: String,
     pub payer: String,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub amount: Hnt,
     pub address: String,
     pub hashlock: String,

--- a/src/models/transactions/dc_coinbase_v1.rs
+++ b/src/models/transactions/dc_coinbase_v1.rs
@@ -5,6 +5,5 @@ use serde::{Deserialize, Serialize};
 pub struct DcCoinbaseV1 {
     pub hash: String,
     pub payee: String,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub amount: Hnt,
 }

--- a/src/models/transactions/mod.rs
+++ b/src/models/transactions/mod.rs
@@ -264,7 +264,10 @@ mod test {
             .await
             .expect("StateChannelCloseV1");
         if let Transaction::StateChannelCloseV1(sc) = txn {
-            assert_eq!(sc.height, 861884)
+            assert_eq!(
+                sc.closer,
+                "11QVeYckasapcrmqjZqtfGTjE154uHHUvYPPwW6EMwzrpsdr213"
+            )
         } else {
             assert!(false)
         }

--- a/src/models/transactions/mod.rs
+++ b/src/models/transactions/mod.rs
@@ -120,7 +120,7 @@ mod test {
 
     #[test]
     async fn txn() {
-        let client = Client::default();
+        let client = get_test_client();
         let txn = transactions::get(&client, "1gidN7e6OKn405Fru_0sGhsqca3lTsrfGKrM4dwM_E8")
             .await
             .expect("PocRequestV1");
@@ -135,7 +135,7 @@ mod test {
     }
     #[test]
     async fn consensus_group_v1() {
-        let client = Client::default();
+        let client = get_test_client();
         let txn = transactions::get(&client, "yh01SJk8dvyqb-BGXxkHFUuLi6wF1pfL0VEFStJUt-E")
             .await
             .expect("ConsensusGroupV1");
@@ -148,7 +148,7 @@ mod test {
     #[test]
     async fn payment_v2() {
         //dosqfzzaYtoGx278w4Xu5dnYt7aSZIkD1-IbtiiLQQM
-        let client = Client::default();
+        let client = get_test_client();
         let txn = transactions::get(&client, "C_jJZLKBOv_gRQ6P6wEpZPiRVAjf44FOx1iHOFD4haA")
             .await
             .expect("PaymentV2");
@@ -160,7 +160,7 @@ mod test {
     }
     #[test]
     async fn poc_receipts_v1() {
-        let client = Client::default();
+        let client = get_test_client();
         let txn = transactions::get(&client, "8RaF-G4pvMVuIXfBYhdqNuIlFSEHPm_rC8TH-h4JYdE")
             .await
             .expect("PocReceipt");
@@ -173,7 +173,7 @@ mod test {
 
     #[test]
     async fn payment_v1() {
-        let client = Client::default();
+        let client = get_test_client();
         let txn = transactions::get(&client, "iMSckt_hUcMFY_d7W-QOupY0MGq_g3-CC2dq3P-HWIw")
             .await
             .expect("PaymentV1");
@@ -188,7 +188,7 @@ mod test {
     }
     #[test]
     async fn rewards_v2() {
-        let client = Client::default();
+        let client = get_test_client();
         let txn = transactions::get(&client, "X0HNRGZ1HAX51CR8qS6LTopAosjFkuaaKXl850IpNDE")
             .await
             .expect("RewardsV2");
@@ -200,7 +200,7 @@ mod test {
     }
     #[test]
     async fn assert_location_v1() {
-        let client = Client::default();
+        let client = get_test_client();
         let txn = transactions::get(&client, "_I16bycHeltuOo7eyqa4uhv2Bc7awcztZflyvRkVZ24")
             .await
             .expect("AssertLocationV1");
@@ -212,7 +212,7 @@ mod test {
     }
     #[test]
     async fn assert_location_v2() {
-        let client = Client::default();
+        let client = get_test_client();
         let txn = transactions::get(&client, "TfjRv733Q9FBQ1_unw1c9g5ewVmMBuyf7APuyxKEqrw")
             .await
             .expect("AssertLocationV2");
@@ -227,7 +227,7 @@ mod test {
     }
     #[test]
     async fn add_gateway_v1() {
-        let client = Client::default();
+        let client = get_test_client();
         let txn = transactions::get(&client, "aoTggHSgaBAamuUUrXnY42jDZ5WUBxE0k-tshvfn35E")
             .await
             .expect("AddGatewayV1");
@@ -243,7 +243,7 @@ mod test {
 
     #[test]
     async fn add_gateway_v1_error() {
-        let client = Client::default();
+        let client = get_test_client();
         let txn = transactions::get(&client, "ia3c386ZnlVJorvo60WtXEFxy_0w35ImoIdmnW5lpJ8")
             .await
             .expect("AddGatewayV1");
@@ -259,7 +259,7 @@ mod test {
 
     #[test]
     async fn state_channel_close_v1() {
-        let client = Client::default();
+        let client = get_test_client();
         let txn = transactions::get(&client, "vjtEQK0vn1w69fV3TMrlnN6L_qprsoWM_-7DVspmLL8")
             .await
             .expect("StateChannelCloseV1");
@@ -272,7 +272,7 @@ mod test {
 
     #[test]
     async fn transfer_hotspot_v1() {
-        let client = Client::default();
+        let client = get_test_client();
         let txn = transactions::get(&client, "fSFua7A8G41K05QXAvJi5N2OB0QqmQ7xp7u-My4rYHc")
             .await
             .expect("TransferHotspotV1");
@@ -288,7 +288,7 @@ mod test {
 
     #[test]
     async fn transfer_routing_v1_new_xor() {
-        let client = Client::default();
+        let client = get_test_client();
 
         let txn = transactions::get(&client, "EjL6nBsSxovJluW-kdAaPcEiRt0OPIATOmlHD1Lth4Y")
             .await
@@ -312,7 +312,7 @@ mod test {
 
     #[test]
     async fn unstake_validator_v1() {
-        let client = Client::default();
+        let client = get_test_client();
 
         let txn = transactions::get(&client, "fMT-7_f2WQNKAYIQWX2-V258KsoI61HYbt_zAbN3A1I")
             .await
@@ -332,7 +332,7 @@ mod test {
 
     #[test]
     async fn vars_v1() {
-        let client = Client::default();
+        let client = get_test_client();
         let txn = transactions::get(&client, "SB47bwBKP3ud1KdASYAndxkoIhZCXgPtusLUIsS7Q2o")
             .await
             .expect("VarsV1");

--- a/src/models/transactions/oui_v1.rs
+++ b/src/models/transactions/oui_v1.rs
@@ -10,7 +10,6 @@ pub struct OuiV1 {
     pub payer: String,
     pub filter: String,
     pub addresses: Vec<String>,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub staking_fee: Hnt,
     pub requested_subnet_size: u64,
 }

--- a/src/models/transactions/payment_v1.rs
+++ b/src/models/transactions/payment_v1.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct PaymentV1 {
     pub hash: String,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub amount: Hnt,
     pub fee: u64,
     pub nonce: u64,

--- a/src/models/transactions/payment_v2.rs
+++ b/src/models/transactions/payment_v2.rs
@@ -13,7 +13,6 @@ pub struct PaymentV2 {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct PaymentV2Payment {
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub amount: Hnt,
     pub memo: Option<String>,
     pub payee: String,

--- a/src/models/transactions/reward.rs
+++ b/src/models/transactions/reward.rs
@@ -1,9 +1,10 @@
+use crate::models::Hnt;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Reward {
     pub account: Option<String>,
-    pub amount: u64,
+    pub amount: Hnt,
     pub gateway: Option<String>,
     pub r#type: String,
 }

--- a/src/models/transactions/security_exchange_v1.rs
+++ b/src/models/transactions/security_exchange_v1.rs
@@ -8,6 +8,5 @@ pub struct SecurityExchangeV1 {
     pub nonce: u64,
     pub payee: String,
     pub payer: String,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub amount: Hnt,
 }

--- a/src/models/transactions/stake_validator_v1.rs
+++ b/src/models/transactions/stake_validator_v1.rs
@@ -7,7 +7,6 @@ pub struct StakeValidatorV1 {
     pub fee: u64,
     pub hash: String,
     pub owner: String,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub stake: Hnt,
     pub owner_signature: String,
 }

--- a/src/models/transactions/state_channel_open_v1.rs
+++ b/src/models/transactions/state_channel_open_v1.rs
@@ -9,7 +9,6 @@ pub struct StateChannelOpenV1 {
     pub hash: String,
     pub nonce: u64,
     pub owner: String,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub amount: Hnt,
     pub expire_within: u64,
 }

--- a/src/models/transactions/token_burn_v1.rs
+++ b/src/models/transactions/token_burn_v1.rs
@@ -9,6 +9,5 @@ pub struct TokenBurnV1 {
     pub nonce: u64,
     pub payee: String,
     pub payer: String,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub amount: Hnt,
 }

--- a/src/models/transactions/transfer_hotspot_v1.rs
+++ b/src/models/transactions/transfer_hotspot_v1.rs
@@ -9,6 +9,5 @@ pub struct TransferHotspotV1 {
     pub seller: String,
     pub gateway: String,
     pub buyer_nonce: u64,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub amount_to_seller: Hnt,
 }

--- a/src/models/transactions/transfer_validator_stake_v1.rs
+++ b/src/models/transactions/transfer_validator_stake_v1.rs
@@ -12,8 +12,6 @@ pub struct TransferValidatorStakeV1 {
     pub old_address: String,
     pub old_owner: String,
     pub old_owner_signature: String,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub payment_amount: Hnt,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub stake_amount: Hnt,
 }

--- a/src/models/transactions/unstake_validator_v1.rs
+++ b/src/models/transactions/unstake_validator_v1.rs
@@ -7,7 +7,6 @@ pub struct UnstakeValidatorV1 {
     pub owner: String,
     pub owner_signature: String,
     pub fee: u64,
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub stake_amount: Hnt,
     pub stake_release_height: u64,
     pub hash: String,

--- a/src/models/validator.rs
+++ b/src/models/validator.rs
@@ -12,7 +12,6 @@ pub struct Validator {
     /// the owner of the validator.
     pub owner: String,
     /// The staked amount for the validator
-    #[serde(deserialize_with = "Hnt::deserialize")]
     pub stake: Hnt,
     /// The last heartbeat transaction of the validator
     pub last_heartbeat: u64,

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -38,7 +38,7 @@ mod test {
 
     #[test]
     async fn all() {
-        let client = Client::default();
+        let client = get_test_client();
         let prices = oracle::prices::all(&client)
             .take(10)
             .into_vec()
@@ -49,14 +49,14 @@ mod test {
 
     #[test]
     async fn current() {
-        let client = Client::default();
+        let client = get_test_client();
         let price = oracle::prices::current(&client).await.expect("price");
         assert!(price.block > 0);
     }
 
     #[test]
     async fn at_block() {
-        let client = Client::default();
+        let client = get_test_client();
         let price = oracle::prices::at_block(&client, 763816)
             .await
             .expect("price");
@@ -65,7 +65,7 @@ mod test {
 
     #[test]
     async fn predictions() {
-        let client = Client::default();
+        let client = get_test_client();
         let predictions = oracle::predictions(&client).await;
         // predictions may be an empty list
         assert!(predictions.is_ok());

--- a/src/ouis.rs
+++ b/src/ouis.rs
@@ -30,14 +30,14 @@ mod test {
 
     #[test]
     async fn all() {
-        let client = Client::default();
+        let client = get_test_client();
         let ouis = ouis::all(&client).into_vec().await.expect("ouis");
         assert!(ouis.len() > 0);
     }
 
     #[test]
     async fn get() {
-        let client = Client::default();
+        let client = get_test_client();
         let oui = ouis::get(&client, 1).await.expect("oui");
         assert_eq!(
             oui.owner,
@@ -47,14 +47,14 @@ mod test {
 
     #[test]
     async fn last() {
-        let client = Client::default();
+        let client = get_test_client();
         let oui = ouis::last(&client).await.expect("oui");
         assert!(oui.oui >= 1,);
     }
 
     #[test]
     async fn stats() {
-        let client = Client::default();
+        let client = get_test_client();
         let stats = ouis::stats(&client).await.expect("stats");
         assert!(stats.count >= 1,);
     }

--- a/src/vars.rs
+++ b/src/vars.rs
@@ -27,7 +27,7 @@ mod test {
 
     #[test]
     async fn named() {
-        let client = Client::default();
+        let client = get_test_client();
         let vars = vars::get_named(&client, &["txn_fees"])
             .await
             .expect("named vars");


### PR DESCRIPTION
Previously, the types with Hnt in them were impossible to do roundtrip serializations with.

For example, payment_v1:
```rust
#[derive(Clone, Serialize, Deserialize, Debug)]
pub struct PaymentV1 {
    pub hash: String,
    #[serde(deserialize_with = "Hnt::deserialize")]
    pub amount: Hnt,
    pub fee: u64,
    pub nonce: u64,
}
```

Hnt::deserialize would be used when deserializing, yet the derived serialization from Decimal  was used for serializing.

To fix the issue, the Serialize/Deserialize implementation is done by hand, using the u64 serialization from what was formerly `Hnt::deserialize`. With this change, the serde override attribute is no longer necessary either.

There are a few fixes included in this PR as well:

- the type `amount` in the reward struct was u64 instead of Hnt
- the unit tests were all broken since the `fn Client::default()` was deprecated.

