### PR TITLE
add StateChannel struct to conflicts_with field

### DIFF
--- a/src/models/transactions/state_channel_close_v1.rs
+++ b/src/models/transactions/state_channel_close_v1.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 pub struct StateChannelCloseV1 {
     pub hash: String,
     pub state_channel: StateChannel,
-    pub conflicts_with: Option<String>,
+    pub conflicts_with: Option<StateChannel>,
     pub closer: String,
 }
 


### PR DESCRIPTION
This adds the StateChannel struct to the `conflicts_with` field instead of a String. Otherwise there is an error while trying to deserialize state_channel_close_v1 txns that have a value for `conflicts_with`.

ex. 

`let txn = transactions::get(&client, "h_WqM7ntdD6AMy2eLuCTb49dNTx0WnVg_Q_qzsvaa8w").await?; `

will throw an error for this client and also the [JSONRPC](https://github.com/dewi-alliance/helium-jsonrpc-rs) client.