### PR TITLE
slow down tests to avoid API throttling

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
           args: -- -Dclippy::all
 
       - name: Run tests
-        run: cargo test
+        run: cargo test -- --test-threads 1
 
       - name: Build
         run: cargo build --all

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,8 @@ jobs:
 
       - name: Run tests
         run: cargo test -- --test-threads 1
-
+        env:
+          TEST_DELAY_MS: 1000
       - name: Build
         run: cargo build --all
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,10 +186,14 @@ pub trait IntoVec: StreamExt {
 
 #[cfg(test)]
 fn get_test_client() -> Client {
-    use std::{thread, time};
+    use std::{env, thread, time};
     const USER_AGENT: &str = "helium-api-test/0.1.0";
     const BASE_URL: &str = "https://api.helium.io/v1";
-    let ten_millis = time::Duration::from_millis(1000);
-    thread::sleep(ten_millis);
+    let duration = time::Duration::from_millis(if let Some(delay) = env::var("TEST_DELAY_MS") {
+        delay
+    } else {
+        0
+    });
+    thread::sleep(duration);
     Client::new_with_base_url(BASE_URL.into(), USER_AGENT)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,11 +189,12 @@ fn get_test_client() -> Client {
     use std::{env, thread, time};
     const USER_AGENT: &str = "helium-api-test/0.1.0";
     const BASE_URL: &str = "https://api.helium.io/v1";
-    let duration = time::Duration::from_millis(if let Some(delay) = env::var("TEST_DELAY_MS") {
-        delay
-    } else {
-        0
-    });
+    let duration = time::Duration::from_millis(
+        env::var("TEST_DELAY_MS")
+            .unwrap_or("0".to_string())
+            .parse::<u64>()
+            .expect("TEST_DELAY_MS cannot be parsed as u64"),
+    );
     thread::sleep(duration);
     Client::new_with_base_url(BASE_URL.into(), USER_AGENT)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,10 @@ pub trait IntoVec: StreamExt {
 
 #[cfg(test)]
 fn get_test_client() -> Client {
+    use std::{thread, time};
     const USER_AGENT: &str = "helium-api-test/0.1.0";
     const BASE_URL: &str = "https://api.helium.io/v1";
+    let ten_millis = time::Duration::from_millis(1000);
+    thread::sleep(ten_millis);
     Client::new_with_base_url(BASE_URL.into(), USER_AGENT)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,12 +189,10 @@ fn get_test_client() -> Client {
     use std::{env, thread, time};
     const USER_AGENT: &str = "helium-api-test/0.1.0";
     const BASE_URL: &str = "https://api.helium.io/v1";
-    let duration = time::Duration::from_millis(
-        env::var("TEST_DELAY_MS")
-            .unwrap_or("0".to_string())
-            .parse::<u64>()
-            .expect("TEST_DELAY_MS cannot be parsed as u64"),
-    );
+    let duration = time::Duration::from_millis(env::var("TEST_DELAY_MS").map_or(0, |v| {
+        v.parse::<u64>()
+            .expect("TEST_DELAY_MS cannot be parsed as u64")
+    }));
     thread::sleep(duration);
     Client::new_with_base_url(BASE_URL.into(), USER_AGENT)
 }


### PR DESCRIPTION
The API will throttle tests. In the future, maybe we could create a token or a secured endpoint.