### PR TITLE
add API endpoint to get pending transactions for an account

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -44,6 +44,7 @@ pub fn activity(client: &Client, address: &str, query: &QueryTimeRange) -> Strea
     client.fetch_stream(&format!("/accounts/{}/activity", address), query)
 }
 
+/// Fetch all pending transactions for an account
 pub fn pending(client: &Client, address: &str) -> Stream<Transaction> {
     client.fetch_stream(
         &format!("/accounts/{}/pending_transactions", address),


### PR DESCRIPTION
update helium-api-rs to include an endpoint not included [here](https://docs.helium.com/api/blockchain/accounts)
