### PR TITLE
remove block from TransferValidatorStakeV1

### DIFF
--- a/src/models/transactions/transfer_validator_stake_v1.rs
+++ b/src/models/transactions/transfer_validator_stake_v1.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct TransferValidatorStakeV1 {
-    pub block: u64,
     pub fee: u64,
     pub hash: String,
     pub new_address: String,


### PR DESCRIPTION
Consistent with #55 , this type should not include "block".